### PR TITLE
Bring back support for grok patterns containing named groups with underscore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
 			<version>1.7.21</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.tony19</groupId>
+			<artifactId>named-regexp</artifactId>
+			<version>${named.regex.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 		<assertj.version>3.9.1</assertj.version>
 		<common.version>3.7</common.version>
 		<guava.version>24.0-jre</guava.version>
+		<named.regex.version>0.2.3</named.regex.version>
 		<!-- maven -->
 		<java.version>1.8</java.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,273 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.graylog2.repackaged</groupId>
+	<artifactId>grok</artifactId>
+	<version>0.1.19-graylog-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Grok</name>
+	<description>Simple API that allows you to easily parse logs and other files</description>
+	<url>http://maven.apache.org</url>
+
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<id>anthony-corbacho</id>
+			<name>Anthony Corbacho</name>
+			<email>corbacho.anthony@gmail.com</email>
+			<organization>Thekraken</organization>
+			<organizationUrl>http://release.thekraken.io</organizationUrl>
+			<url>https://github.com/anthonycorbacho</url>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git@github.com:Graylog2/java-grok.git</connection>
+		<developerConnection>scm:git:git@github.com:Graylog2/java-grok.git</developerConnection>
+		<url>scm:git:git@github.com:Graylog2/java-grok.git</url>
+	</scm>
+
+	<ciManagement>
+		<system>Travis</system>
+		<url>https://travis-ci.org/thekrakken/java-grok</url>
+	</ciManagement>
+
+	<issueManagement>
+		<system>Github</system>
+		<url>https://github.com/thekrakken/java-grok/issues</url>
+	</issueManagement>
+
+	<properties>
+		<junit.version>4.12</junit.version>
+		<assertj.version>3.9.1</assertj.version>
+		<common.version>3.7</common.version>
+		<guava.version>24.0-jre</guava.version>
+		<!-- maven -->
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${common.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.21</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.9.1</version>
+				<configuration><!-- Default configuration for all reports -->
+				</configuration>
+				<executions>
+					<execution>
+						<id>aggregate</id>
+						<goals>
+							<goal>aggregate</goal>
+						</goals>
+						<phase>site</phase>
+						<configuration><!-- Specific configuration for the aggregate report -->
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<artifactId>maven-scm-plugin</artifactId>
+				<version>1.8.1</version>
+				<configuration>
+					<connectionType>developerConnection</connectionType>
+					<scmVersion>branch-0.1</scmVersion>
+					<scmVersionType>branch</scmVersionType>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.3.1</version>
+				<executions>
+					<execution>
+						<id>enforce</id>
+						<configuration>
+							<rules>
+								<DependencyConvergence />
+							</rules>
+							<failFast>true</failFast>
+						</configuration>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>2.8</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.16</version>
+					<configuration combine.children="append">
+						<argLine>-Xmx2g -Xms1g</argLine>
+					</configuration>
+				</plugin>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>2.4</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>exec-maven-plugin</artifactId>
+					<version>1.2.1</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>2.4.1</version>
+					<configuration>
+						<filesets>
+							<fileset>
+								<directory>drivers</directory>
+								<followSymlinks>false</followSymlinks>
+							</fileset>
+						</filesets>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>build-distr</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<artifactId>maven-surefire-plugin</artifactId>
+							<configuration>
+								<skipTests>true</skipTests>
+							</configuration>
+						</plugin>
+						<plugin>
+							<artifactId>maven-assembly-plugin</artifactId>
+							<executions>
+								<execution>
+									<id>make-assembly</id>
+									<phase>package</phase>
+									<goals>
+										<goal>single</goal>
+									</goals>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
+		<profile>
+			<id>publish-distr</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<skipTests>true</skipTests>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>release-sign-artifacts</id>
+			<activation>
+				<property>
+					<name>performRelease</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.4</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/src/main/java/io/krakens/grok/api/Converter.java
+++ b/src/main/java/io/krakens/grok/api/Converter.java
@@ -15,9 +15,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.google.code.regexp.Pattern;
 /**
  * Convert String argument to the right type.
  *

--- a/src/main/java/io/krakens/grok/api/Discovery.java
+++ b/src/main/java/io/krakens/grok/api/Discovery.java
@@ -8,11 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
 
 /**
  * {@code Discovery} try to find the best pattern for the given string.

--- a/src/main/java/io/krakens/grok/api/Grok.java
+++ b/src/main/java/io/krakens/grok/api/Grok.java
@@ -5,10 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import io.krakens.grok.api.Converter.IConverter;
+
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/src/main/java/io/krakens/grok/api/GrokCompiler.java
+++ b/src/main/java/io/krakens/grok/api/GrokCompiler.java
@@ -160,13 +160,12 @@ public class GrokCompiler {
       }
       iterationLeft--;
 
-      Set<String> namedGroups = GrokUtils.getNameGroups(GrokUtils.GROK_PATTERN.toString());
       Matcher matcher = GrokUtils.GROK_PATTERN.matcher(namedRegex);
       // Match %{Foo:bar} -> pattern name and subname
       // Match %{Foo=regex} -> add new regex definition
       if (matcher.find()) {
         continueIteration = true;
-        Map<String, String> group = GrokUtils.namedGroups(matcher, namedGroups);
+        Map<String, String> group = matcher.namedGroups();
         if (group.get("definition") != null) {
           patternDefinitions.put(group.get("pattern"), group.get("definition"));
           group.put("name", group.get("name") + "=" + group.get("definition"));

--- a/src/main/java/io/krakens/grok/api/GrokCompiler.java
+++ b/src/main/java/io/krakens/grok/api/GrokCompiler.java
@@ -15,8 +15,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
+
 
 import io.krakens.grok.api.exception.GrokException;
 
@@ -158,7 +160,7 @@ public class GrokCompiler {
       }
       iterationLeft--;
 
-      Set<String> namedGroups = GrokUtils.getNameGroups(GrokUtils.GROK_PATTERN.pattern());
+      Set<String> namedGroups = GrokUtils.getNameGroups(GrokUtils.GROK_PATTERN.toString());
       Matcher matcher = GrokUtils.GROK_PATTERN.matcher(namedRegex);
       // Match %{Foo:bar} -> pattern name and subname
       // Match %{Foo=regex} -> add new regex definition

--- a/src/main/java/io/krakens/grok/api/GrokUtils.java
+++ b/src/main/java/io/krakens/grok/api/GrokUtils.java
@@ -44,13 +44,4 @@ public class GrokUtils {
     }
     return namedGroups;
   }
-
-  public static Map<String, String> namedGroups(Matcher matcher, Set<String> groupNames) {
-    Map<String, String> namedGroups = new LinkedHashMap<>();
-    for (String groupName : groupNames) {
-      String groupValue = matcher.group(groupName);
-      namedGroups.put(groupName, groupValue);
-    }
-    return namedGroups;
-  }
 }

--- a/src/main/java/io/krakens/grok/api/GrokUtils.java
+++ b/src/main/java/io/krakens/grok/api/GrokUtils.java
@@ -34,7 +34,7 @@ public class GrokUtils {
           + "\\}");
 
   public static final Pattern NAMED_REGEX = Pattern
-      .compile("\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>");
+      .compile("\\(\\?<([a-zA-Z][a-zA-Z0-9_]*)>");
 
   public static Set<String> getNameGroups(String regex) {
     Set<String> namedGroups = new LinkedHashSet<>();

--- a/src/main/java/io/krakens/grok/api/GrokUtils.java
+++ b/src/main/java/io/krakens/grok/api/GrokUtils.java
@@ -4,8 +4,9 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
 
 
 /**

--- a/src/main/java/io/krakens/grok/api/Match.java
+++ b/src/main/java/io/krakens/grok/api/Match.java
@@ -129,7 +129,7 @@ public class Match {
     // _capture.put("LINE", this.line);
     // _capture.put("LENGTH", this.line.length() +"");
 
-    Map<String, String> mappedw = GrokUtils.namedGroups(this.match, this.grok.namedGroups);
+    Map<String, String> mappedw = this.match.namedGroups();
 
     mappedw.forEach((key, valueString) -> {
       String id = this.grok.getNamedRegexCollectionById(key);

--- a/src/main/java/io/krakens/grok/api/Match.java
+++ b/src/main/java/io/krakens/grok/api/Match.java
@@ -8,7 +8,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
+
+import com.google.code.regexp.Matcher;
+
 
 import io.krakens.grok.api.Converter.IConverter;
 import io.krakens.grok.api.exception.GrokException;

--- a/src/main/resources/patterns/patterns
+++ b/src/main/resources/patterns/patterns
@@ -106,3 +106,6 @@ COMMONAPACHELOG_DATATYPED %{IPORHOST:clientip} %{USER:ident;boolean} %{USER:auth
 
 # Log Levels
 LOGLEVEL ([A|a]lert|ALERT|[T|t]race|TRACE|[D|d]ebug|DEBUG|[N|n]otice|NOTICE|[I|i]nfo|INFO|[W|w]arn?(?:ing)?|WARN?(?:ING)?|[E|e]rr?(?:or)?|ERR?(?:OR)?|[C|c]rit?(?:ical)?|CRIT?(?:ICAL)?|[F|f]atal|FATAL|[S|s]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)
+
+# NamedGroup with underscore
+NAMEDGROUPWITHUNDERSCORE (?<test_field>test)

--- a/src/test/java/io/krakens/grok/api/BasicTest.java
+++ b/src/test/java/io/krakens/grok/api/BasicTest.java
@@ -129,9 +129,9 @@ public class BasicTest {
 
   @Test
   public void test008_namedGroupPatternWithUnderscore() throws GrokException {
-    compiler.register("test", "hello world");
+    compiler.register("test", "(?<test_field>test)");
     Grok grok = compiler.compile("%{test}");
-    assertEquals("(?<name_0>hello world)", grok.getNamedRegex());
+    assertEquals("(?<name0>(?<test_field>test))", grok.getNamedRegex());
   }
 
 }

--- a/src/test/java/io/krakens/grok/api/BasicTest.java
+++ b/src/test/java/io/krakens/grok/api/BasicTest.java
@@ -14,7 +14,9 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
 import io.krakens.grok.api.exception.GrokException;
@@ -132,6 +134,20 @@ public class BasicTest {
     compiler.register("test", "(?<test_field>test)");
     Grok grok = compiler.compile("%{test}");
     assertEquals("(?<name0>(?<test_field>test))", grok.getNamedRegex());
+    Set<String> expectedNamedGroups = new HashSet<>(2);
+    expectedNamedGroups.add("name0");
+    expectedNamedGroups.add("test_field");
+    assertEquals(expectedNamedGroups, grok.namedGroups);
   }
 
+  @Test
+  public void test009_namedGroupPattern() throws GrokException {
+    compiler.register("test", "(?<testfield>test)");
+    Grok grok = compiler.compile("%{test}");
+    assertEquals("(?<name0>(?<testfield>test))", grok.getNamedRegex());
+    Set<String> expectedNamedGroups = new HashSet<>(2);
+    expectedNamedGroups.add("name0");
+    expectedNamedGroups.add("testfield");
+    assertEquals(expectedNamedGroups, grok.namedGroups);
+  }
 }

--- a/src/test/java/io/krakens/grok/api/BasicTest.java
+++ b/src/test/java/io/krakens/grok/api/BasicTest.java
@@ -127,4 +127,11 @@ public class BasicTest {
     assertEquals("(?<name0>€)", grok.getNamedRegex());
   }
 
+  @Test
+  public void test008_namedGroupPatternWithUnderscore() throws GrokException {
+    compiler.register("test", "hello world");
+    Grok grok = compiler.compile("%{test}");
+    assertEquals("(?<name_0>hello world)", grok.getNamedRegex());
+  }
+
 }

--- a/src/test/java/io/krakens/grok/api/GrokTest.java
+++ b/src/test/java/io/krakens/grok/api/GrokTest.java
@@ -21,10 +21,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import io.krakens.grok.api.exception.GrokException;
+
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;

--- a/src/test/java/io/krakens/grok/api/GrokTest.java
+++ b/src/test/java/io/krakens/grok/api/GrokTest.java
@@ -672,4 +672,13 @@ public class GrokTest {
     instant = (Instant) grok.match(dateWithTimeZone).capture().get("timestamp");
     assertEquals(ZonedDateTime.parse(dateWithTimeZone, dtf.withZone(ZoneOffset.ofHours(8))).toInstant(), instant);
   }
+
+  @Test
+  public void testNamedGroupWithUnderscore() {
+    String grokPatternName = "NAMEDGROUPWITHUNDERSCORE";
+    String testString = "test";
+    Grok grok = compiler.compile("%{" + grokPatternName + "}");
+    String result = (String) grok.match(testString).capture().get(grokPatternName);
+    assertEquals("test", result);
+  }
 }


### PR DESCRIPTION
Grok Patterns with named groups (`(?<name0>test)`) can contain a name with a underscore (`(?<my_name>test)`).

The java-grok library dropped the support unintentionally by moving the regex Engine from "named-regexp" to java (https://github.com/thekrakken/java-grok/pull/53).

To preserve the support this PR switches back from java to "named-regexp".