### PR TITLE
Change captureFlatten behavior

### DIFF
--- a/src/main/resources/patterns/patterns
+++ b/src/main/resources/patterns/patterns
@@ -107,5 +107,11 @@ COMMONAPACHELOG_DATATYPED %{IPORHOST:clientip} %{USER:ident;boolean} %{USER:auth
 # Log Levels
 LOGLEVEL ([A|a]lert|ALERT|[T|t]race|TRACE|[D|d]ebug|DEBUG|[N|n]otice|NOTICE|[I|i]nfo|INFO|[W|w]arn?(?:ing)?|WARN?(?:ING)?|[E|e]rr?(?:or)?|ERR?(?:OR)?|[C|c]rit?(?:ical)?|CRIT?(?:ICAL)?|[F|f]atal|FATAL|[S|s]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)
 
+# Flatten Test
+TEST1 test1
+TEST2 test2
+ORTEST (%{TEST1:test}|%{TEST2:test})
+TWOINTS %{INT} %{INT}
+
 # NamedGroup with underscore
 NAMEDGROUPWITHUNDERSCORE (?<test_field>test)

--- a/src/test/java/io/krakens/grok/api/CaptureTest.java
+++ b/src/test/java/io/krakens/grok/api/CaptureTest.java
@@ -127,6 +127,7 @@ public class CaptureTest {
 
   @Test
   public void test009_capturedFlattenBehavior() throws GrokException {
+    /* Test flatten with OR where the first result is not null [test1, null] */
     final Grok grok1 = compiler.compile("%{ORTEST}");
     final Match match1 = grok1.match("test1");
     final Map<String, Object> map1 = match1.captureFlattened();
@@ -134,12 +135,14 @@ public class CaptureTest {
     assertEquals("test1",map1.get("test"));
     assertEquals("test1", map1.get("ORTEST"));
 
+    /* Test flatten with OR where the second result is not null [null, test2] */
     final Match match2 = grok1.match("test2");
     final Map<String, Object> map2 = match2.captureFlattened();
     assertEquals(map2.size(),2);
     assertEquals("test2", map2.get("test"));
     assertEquals("test2", map2.get("ORTEST"));
 
+    /* Test flatten with a multiple non unique result [ 22, 23 ] */
     final Grok grok2 = compiler.compile("%{TWOINTS}");
     final Match match3 = grok2.match("22 23");
     final Map<String, Object> map3 = match3.captureFlattened();
@@ -147,8 +150,9 @@ public class CaptureTest {
     assertEquals("22 23", map3.get("TWOINTS"));
     assertEquals(Arrays.asList("22", "23"), map3.get("INT"));
 
+    /* Test flatten with a multiple but unique result [ 22, 22 ] */
     final Grok grok3 = compiler.compile("%{TWOINTS}");
-    final Match match4 = grok2.match("22 22");
+    final Match match4 = grok3.match("22 22");
     final Map<String, Object> map4 = match4.captureFlattened();
     assertEquals(2, map4.size());
     assertEquals("22 22", map4.get("TWOINTS"));

--- a/src/test/java/io/krakens/grok/api/CaptureTest.java
+++ b/src/test/java/io/krakens/grok/api/CaptureTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -145,5 +147,35 @@ public class CaptureTest {
       assertThat(e.getMessage(),
           containsString("has multiple non-null values, this is not allowed in flattened mode"));
     }
+  }
+
+  @Test
+  public void test009_capturedFlattenBehavior() throws GrokException {
+    final Grok grok1 = compiler.compile("%{ORTEST}");
+    final Match match1 = grok1.match("test1");
+    final Map<String, Object> map1 = match1.captureFlattened();
+    assertEquals(map1.size(), 2);
+    assertEquals("test1",map1.get("test"));
+    assertEquals("test1", map1.get("ORTEST"));
+
+    final Match match2 = grok1.match("test2");
+    final Map<String, Object> map2 = match2.captureFlattened();
+    assertEquals(map2.size(),2);
+    assertEquals("test2", map2.get("test"));
+    assertEquals("test2", map2.get("ORTEST"));
+
+    final Grok grok2 = compiler.compile("%{TWOINTS}");
+    final Match match3 = grok2.match("22 23");
+    final Map<String, Object> map3 = match3.captureFlattened();
+    assertEquals(2, map3.size());
+    assertEquals("22 23", map3.get("TWOINTS"));
+    assertEquals(Arrays.asList("22", "23"), map3.get("INT"));
+
+    final Grok grok3 = compiler.compile("%{TWOINTS}");
+    final Match match4 = grok2.match("22 22");
+    final Map<String, Object> map4 = match4.captureFlattened();
+    assertEquals(2, map4.size());
+    assertEquals("22 22", map4.get("TWOINTS"));
+    assertEquals("22", map4.get("INT"));
   }
 }

--- a/src/test/java/io/krakens/grok/api/CaptureTest.java
+++ b/src/test/java/io/krakens/grok/api/CaptureTest.java
@@ -126,30 +126,6 @@ public class CaptureTest {
   }
 
   @Test
-  public void test008_flattenDuplicateKeys() throws GrokException {
-    Grok grok = compiler.compile("(?:foo %{INT:id} bar|bar %{INT:id} foo)");
-    Match match = grok.match("foo 123 bar");
-    Map<String, Object> map = match.captureFlattened();
-    assertEquals(map.size(), 1);
-    assertEquals(map.get("id"), "123");
-    Match m2 = grok.match("bar 123 foo");
-    map = m2.captureFlattened();
-    assertEquals(map.size(), 1);
-    assertEquals(map.get("id"), "123");
-
-    grok = compiler.compile("%{INT:id} %{INT:id}");
-    Match m3 = grok.match("123 456");
-
-    try {
-      m3.captureFlattened();
-      fail("should report error due tu ambiguity");
-    } catch (RuntimeException e) {
-      assertThat(e.getMessage(),
-          containsString("has multiple non-null values, this is not allowed in flattened mode"));
-    }
-  }
-
-  @Test
   public void test009_capturedFlattenBehavior() throws GrokException {
     final Grok grok1 = compiler.compile("%{ORTEST}");
     final Match match1 = grok1.match("test1");


### PR DESCRIPTION
Prior to this change, if the caputerFlattened result
tried to flatten a result with mutltiple non null
values he raised an exception.

This change will remove any null values from a result
and only return a no array if the result contains only
one value.